### PR TITLE
use docker/spdystream again

### DIFF
--- a/transport/spdystream/spdystream.go
+++ b/transport/spdystream/spdystream.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"net/http"
 
+	ss "github.com/docker/spdystream"
 	pst "github.com/jbenet/go-peerstream/transport"
-	ss "github.com/jbenet/spdystream"
 )
 
 // stream implements pst.Stream using a ss.Stream

--- a/transport/spdystream/spdystream.go
+++ b/transport/spdystream/spdystream.go
@@ -87,10 +87,8 @@ func (c *conn) Serve(handler pst.StreamHandler) {
 		// -- at this moment -- not the solution. Either spdystream must
 		// change, or we must throttle another way. go-peerstream handles
 		// every new stream in its own goroutine.
-		go func() {
-			s.SendReply(http.Header{}, false)
-			handler((*stream)(s))
-		}()
+		s.SendReply(http.Header{}, false)
+		go handler((*stream)(s))
 	})
 }
 

--- a/transport/spdystream/spdystream.go
+++ b/transport/spdystream/spdystream.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"net/http"
 
-	ss "github.com/docker/spdystream"
 	pst "github.com/jbenet/go-peerstream/transport"
+	ss "github.com/jbenet/spdystream"
 )
 
 // stream implements pst.Stream using a ss.Stream

--- a/transport/spdystream/spdystream.go
+++ b/transport/spdystream/spdystream.go
@@ -87,7 +87,13 @@ func (c *conn) Serve(handler pst.StreamHandler) {
 		// -- at this moment -- not the solution. Either spdystream must
 		// change, or we must throttle another way. go-peerstream handles
 		// every new stream in its own goroutine.
-		s.SendReply(http.Header{}, false)
+		err := s.SendReply(http.Header{}, false)
+		if err != nil {
+			// this _could_ error out. not sure how to handle this failure.
+			// don't return, and let the caller handle a broken stream.
+			// better than _hiding_ an error.
+			// return
+		}
 		go handler((*stream)(s))
 	})
 }

--- a/transport/test/ttest.go
+++ b/transport/test/ttest.go
@@ -194,7 +194,7 @@ func SubtestSimpleWrite100msgs(t *testing.T, tr pst.Transport) {
 			bufs <- buf
 			log("writing %d bytes (message %d/%d #%x)", len(buf), i, msgs, buf[:3])
 			if _, err := stream.Write(buf); err != nil {
-				errs <- err
+				errs <- fmt.Errorf("stream.Write(buf): %s", err)
 				continue
 			}
 		}
@@ -212,7 +212,7 @@ func SubtestSimpleWrite100msgs(t *testing.T, tr pst.Transport) {
 			i++
 
 			if _, err := io.ReadFull(stream, buf2); err != nil {
-				errs <- err
+				errs <- fmt.Errorf("readFull(stream, buf2): %s", err)
 				continue
 			}
 			if !bytes.Equal(buf1, buf2) {
@@ -253,7 +253,7 @@ func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm,
 			bufs <- buf
 			log("%p writing %d bytes (message %d/%d #%x)", s, len(buf), i, nMsg, buf[:3])
 			if _, err := s.Write(buf); err != nil {
-				errs <- err
+				errs <- fmt.Errorf("s.Write(buf): %s", err)
 				continue
 			}
 		}
@@ -265,11 +265,12 @@ func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm,
 		buf2 := make([]byte, msgsize)
 		i := 0
 		for buf1 := range bufs {
-			log("%p reading %d bytes (message %d/%d #%x)", s, len(buf1), i, nMsg, buf1[:3])
 			i++
+			log("%p reading %d bytes (message %d/%d #%x)", s, len(buf1), i-1, nMsg, buf1[:3])
 
 			if _, err := io.ReadFull(s, buf2); err != nil {
-				errs <- err
+				errs <- fmt.Errorf("io.ReadFull(s, buf2): %s", err)
+				log("%p failed to read %d bytes (message %d/%d #%x)", s, len(buf1), i-1, nMsg, buf1[:3])
 				continue
 			}
 			if !bytes.Equal(buf1, buf2) {
@@ -307,13 +308,13 @@ func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm,
 
 		nc, err := net.Dial(nla.Network(), nla.String())
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("net.Dial(%s, %s): %s", nla.Network(), nla.String(), err)
 			return
 		}
 
 		c, err := a.AddConn(nc)
 		if err != nil {
-			errs <- err
+			errs <- fmt.Errorf("a.AddConn(%s <--> %s): %s", nc.LocalAddr(), nc.RemoteAddr(), err)
 			return
 		}
 


### PR DESCRIPTION
spdystream has been updated since i last messed with it.
commit log promises important race fixes.
So this PR uses docker/spdystream again, without my fixes.
(it seems they handled what i fixed differently).

But this doesn't pass the peerstream tests :/ it deadlocks. not sure
if its on our side or spdystream's. (i suspect spdystream)