### PR TITLE
Multiplex transport

### DIFF
--- a/transport/multiplex/multiplex.go
+++ b/transport/multiplex/multiplex.go
@@ -1,0 +1,45 @@
+package peerstream_multiplex
+
+import (
+	"net"
+
+	pst "github.com/jbenet/go-peerstream/transport"
+	mp "github.com/whyrusleeping/go-multiplex"
+)
+
+// Conn is a connection to a remote peer.
+type conn struct {
+	*mp.Multiplex
+}
+
+func (c *conn) Close() error {
+	return c.Multiplex.Close()
+}
+
+func (c *conn) IsClosed() bool {
+	return c.Multiplex.IsClosed()
+}
+
+// OpenStream creates a new stream.
+func (c *conn) OpenStream() (pst.Stream, error) {
+	return c.Multiplex.NewStream(), nil
+}
+
+// Serve starts listening for incoming requests and handles them
+// using given StreamHandler
+func (c *conn) Serve(handler pst.StreamHandler) {
+	c.Multiplex.Serve(func(s *mp.Stream) {
+		handler(s)
+	})
+}
+
+// Transport is a go-peerstream transport that constructs
+// multiplex-backed connections.
+type Transport struct{}
+
+// DefaultTransport has default settings for multiplex
+var DefaultTransport = &Transport{}
+
+func (t *Transport) NewConn(nc net.Conn, isServer bool) (pst.Conn, error) {
+	return &conn{mp.NewMultiplex(nc, isServer)}, nil
+}

--- a/transport/multiplex/multiplex_test.go
+++ b/transport/multiplex/multiplex_test.go
@@ -1,0 +1,11 @@
+package peerstream_multiplex
+
+import (
+	"testing"
+
+	psttest "github.com/jbenet/go-peerstream/transport/test"
+)
+
+func TestMultiplexTransport(t *testing.T) {
+	psttest.SubtestAll(t, DefaultTransport)
+}


### PR DESCRIPTION
This adds support for multiplex to allow us to use the go version of @mafintosh's multiplex code as a muxer in go-peerstream