### PR TITLE
added basic header to interop with other spdy impls

### DIFF
--- a/transport/spdystream/spdystream.go
+++ b/transport/spdystream/spdystream.go
@@ -64,7 +64,10 @@ func (c *conn) IsClosed() bool {
 
 // OpenStream creates a new stream.
 func (c *conn) OpenStream() (pst.Stream, error) {
-	s, err := c.spdyConn().CreateStream(http.Header{}, nil, false)
+	s, err := c.spdyConn().CreateStream(http.Header{
+		":method": []string{"GET"}, // this is here for HTTP/SPDY interop
+		":path":   []string{"/"},   // this is here for HTTP/SPDY interop
+	}, nil, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some SPDY implementations are too HTTP focused and do not allow
SPDY-only stream muxing. Meaning, they require HTTP headers. We
set them here as we lose little and can interop with more impls.