### PR TITLE
Fix close deadlock

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -118,12 +118,12 @@ func (c *Conn) Streams() []*Stream {
 // Close closes this connection
 func (c *Conn) Close() error {
 	c.closeLock.Lock()
-	defer c.closeLock.Unlock()
-
 	if c.closed {
+		c.closeLock.Unlock()
 		return nil
 	}
 	c.closed = true
+	c.closeLock.Unlock()
 
 	// close streams
 	streams := c.Streams()

--- a/swarm.go
+++ b/swarm.go
@@ -184,7 +184,7 @@ func (s *Swarm) Conns() []*Conn {
 	open := make([]*Conn, 0, len(conns))
 	for _, c := range conns {
 		if c.smuxConn.IsClosed() {
-			c.Close()
+			c.GoClose()
 		} else {
 			open = append(open, c)
 		}


### PR DESCRIPTION
There was a race condition, where upon closing a conn and all its child
streams, a (potential?) issue in the underlying transport library caused
the 'Close' call to hang, leading to deadlocks in the peerstream code.

This changes the lock to only be held during the closed'ness check, and
should protect go-peerstream users against issues (misunderstandings?)
in the underlying transport libs.