### PR TITLE
add a naive approach to closing idle connections

### DIFF
--- a/timetest/package.json
+++ b/timetest/package.json
@@ -1,0 +1,29 @@
+{
+  "author": "whyrusleeping",
+  "bugs": {
+    "url": "https://github.com/jbenet/go-peerstream"
+  },
+  "gx": {
+    "dvcsimport": "github.com/jbenet/go-peerstream/timetest"
+  },
+  "gxDependencies": [
+    {
+      "author": "whyrusleeping",
+      "hash": "QmVcmcQE9eX4HQ8QwhVXpoHt3ennG7d299NDYFq9D1Uqa1",
+      "name": "go-smux-multistream",
+      "version": "1.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmSHTSkxXGQgaHWz91oZV3CDy3hmKmDgpjbYRT6niACG4E",
+      "name": "go-smux-yamux",
+      "version": "1.1.1"
+    }
+  ],
+  "gxVersion": "0.7.0",
+  "language": "go",
+  "license": "",
+  "name": "timetest",
+  "version": "0.0.0"
+}
+

--- a/timetest/swarm_test.go
+++ b/timetest/swarm_test.go
@@ -1,0 +1,74 @@
+package timeouttest
+
+import (
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	ps "github.com/jbenet/go-peerstream"
+
+	yamux "gx/ipfs/QmSHTSkxXGQgaHWz91oZV3CDy3hmKmDgpjbYRT6niACG4E/go-smux-yamux"
+)
+
+func TestConnTimeout(t *testing.T) {
+	ps.NoStreamCloseTimeout = time.Second / 2
+	ps.GarbageCollectTimeout = time.Second / 10
+	tpt := yamux.DefaultTransport
+	echo := func(s *ps.Stream) {
+		defer s.Close()
+		io.Copy(s, s)
+	}
+
+	swarm1 := ps.NewSwarm(tpt)
+	swarm1.SetStreamHandler(echo)
+
+	swarm2 := ps.NewSwarm(tpt)
+	swarm2.SetStreamHandler(echo)
+
+	list1, err := net.Listen("tcp", "0.0.0.0:7334")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = swarm1.AddListener(list1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := net.Dial("tcp", "127.0.0.1:7334")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	psc, err := swarm2.AddConn(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := psc.NewStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+
+	if len(swarm1.Conns()) != 1 {
+		t.Fatal("should still have one connection")
+	}
+
+	if len(swarm2.Conns()) != 1 {
+		t.Fatal("should still have one connection")
+	}
+
+	s.Close()
+
+	time.Sleep(time.Second)
+	if len(swarm1.Conns()) != 0 {
+		t.Fatal("should have closed connection with no streams")
+	}
+
+	if len(swarm2.Conns()) != 0 {
+		t.Fatal("should have closed connection with no streams")
+	}
+}


### PR DESCRIPTION
This still needs some thought, but what i'm thinking about is having connections close automatically if there are no streams open over them.

With this, we should be able to implement similar timeouts in the dht and bitswap, and actually get to a point where we can close connections to peers and not just have endless buildup over time :)